### PR TITLE
update write_mzml

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 ## chromConverter (development version)
 
+* Fixed `write_mzml` to write DAD spectra correctly.
+* Added chromatograms to mzML files written by `write_mzml`.
 * Fixed bug causing failure to write chromatograms with missing attributes to `.cdf` (thanks to @pbulsink for PR #37).
+* Fixed bug causing failure to write existing timestamp data to `.cdf` files.
 * Added more metadata fields to exported CDF files.
 * Added additional test for writing CDF files with missing attributes.
 

--- a/R/read_mzml.R
+++ b/R/read_mzml.R
@@ -62,6 +62,13 @@ read_mzml <- function(path, format_out = c("matrix", "data.frame", "data.table")
         }
       })
     }
+    data <- data <- purrr::imap(data, function(x, h){
+      attach_metadata_minimal(x, format_out = format_out,
+                              data_format = ifelse(grepl("MS", h), "long",
+                                                   data_format),
+                              parser = "RaMS", source_file = path,
+                              source_file_format = "mzML", scale = NULL)
+      })
   } else if (parser == "mzR"){
     if (!requireNamespace("mzR", quietly = TRUE)) {
       stop(

--- a/R/utils.R
+++ b/R/utils.R
@@ -469,8 +469,9 @@ get_times <- function(x, idx = 1){
   }
   data_format <- attr(x, "data_format")
   data_format <- ifelse(is.null(data_format), "wide", data_format)
+  x <- as.data.frame(x)
   if (data_format == "long"){
-    as.numeric(x[,1])
+    unique(as.numeric(x[,1]))
   } else{
     as.numeric(rownames(x))
   }

--- a/R/write_andi_ms.R
+++ b/R/write_andi_ms.R
@@ -148,7 +148,7 @@ write_andi_ms <- function(x, path_out, sample_name = NULL, force = FALSE,
 #' @author Ethan Bass
 #' @noRd
 format_metadata_for_andi_ms <- function(x, intensity_format, ms_params){
-  datetime <- format(attr(x, "run_datetime"), "%Y%m%d%H%M%S%z")[1]
+  datetime <- format(as.POSIXct(as.POSIXct(attr(x, "run_datetime")), tz = "UTC"), "%Y%m%d%H%M%S%z")[1]
   rt_units <- attr(x, "time_unit")
   rt_units <- ifelse(!is.null(rt_units) && !is.na(rt_units),
                      tolower(rt_units), NA)

--- a/man/write_mzml.Rd
+++ b/man/write_mzml.Rd
@@ -25,8 +25,8 @@ write_mzml(
 \item{sample_name}{The name of the file. If a name is not provided, the name
 will be derived from the \code{sample_name} attribute.}
 
-\item{what}{Which streams to write to mzML: \code{"ms1"}, \code{"ms2"},
-\code{"tic"}, \code{"bpc"}, and/or \code{"dad"}.}
+\item{what}{Which streams to write to mzML: \code{"MS1"}, \code{"MS2"},
+\code{"TIC"}, \code{"BPC"}, and/or \code{"DAD"}.}
 
 \item{instrument_info}{Instrument info to write to mzML file.}
 
@@ -55,7 +55,10 @@ methods based on an explicit Document Object Model (DOM).
 \details{
 The function supports writing various types of spectral data including MS1,
 TIC (Total Ion Current), BPC (Base Peak Chromatogram), and DAD
-(Diode Array Detector) data. Support for MS2 may be added in a future release.
+(Diode Array Detector) data. DAD spectra are written as electromagnetic
+radiation spectra (MS:1000804) using Thermo's naming convention with
+\code{controllerType=4} in the spectrum ID for compatibility with existing
+tools. Support for MS2 may be added in a future release.
 
 If \code{indexed = TRUE}, the function will generate an indexed mzML file, which
 allows faster random access to spectra.

--- a/tests/testthat/test-extra-export.R
+++ b/tests/testthat/test-extra-export.R
@@ -15,7 +15,7 @@ test_that("read_chroms can export 'Agilent' MS files as ANDI MS cdf", {
   tmp <- tempdir()
   x2 <- read_chroms(path, parser = "entab", format_out = "data.table",
                     progress_bar = FALSE,
-                    export_format = "cdf", path_out = tmp)[[1]]
+                    export_format = "cdf", path_out = tmp, force=TRUE)[[1]]
   x2 <- x2[order(rt, mz)]
 
   path_cdf <- fs::path(tmp, gsub(" ", "_", attr(x2,"sample_name")), ext = "cdf")
@@ -88,5 +88,5 @@ test_that("read_chroms can convert CDF to mzML", {
 
   x1 <- read_mzml(mzml_path, what = c("MS1", "metadata"))
   expect_equal(x1$MS1[,c(1:3)], x[[1]], ignore_attr = TRUE)
-  expect_equal(x1$metadata$source_file, basename(attr(x$MS1,"source_file")))
+  expect_equal(x1$metadata$source_file, basename(attr(x$MS1, "source_file")))
 })

--- a/tests/testthat/test-extra-misc.R
+++ b/tests/testthat/test-extra-misc.R
@@ -96,9 +96,9 @@ test_that("read_chroms can read Varian SMS", {
   skip_if_not(file.exists(path_mzml))
 
   tmp <- tempdir()
-
+  # must be in long format to export successfully
   x <- read_chroms(path_sms, progress_bar = FALSE, export_format = "mzml",
-                   data_format = "long", path_out = tmp)[[1]] # must be in long format to export successfully
+                   data_format = "long", path_out = tmp, force = TRUE)[[1]]
 
   path_mzml_cc <- fs::path(tmp, attr(x$MS1, "sample_name"), ext = "mzML")
   on.exit(unlink(path_mzml_cc))
@@ -113,7 +113,7 @@ test_that("read_chroms can read Varian SMS", {
   ms1_mzml$rt <- ms1_mzml$rt / 1000
   expect_equal(as.data.frame(x$MS1), ms1_mzml, tolerance = .0000001,
                ignore_attr = TRUE)
-  expect_equal(as.data.frame(x$MS1), x2$MS1[,c(1:3)], ignore_attr=TRUE)
+  expect_equal(as.data.frame(x$MS1), x2$MS1[,c(1:3)], ignore_attr = TRUE)
 
   # check equality of TIC
   expect_equal(x$TIC[, "rt"], x1$TIC$rt/1000, tolerance = .000001)

--- a/tests/testthat/test-read_chroms.R
+++ b/tests/testthat/test-read_chroms.R
@@ -179,7 +179,7 @@ test_that("read_mzml works", {
   colnames(dad_long$DAD)[3] <- "int"
   expect_equal(dad_long,
                RaMS::grabMSdata(files = DAD_filepath, grab_what = "DAD",
-                                verbosity = FALSE)
+                                verbosity = FALSE), ignore_attr =TRUE
   )
   dad_wide <- read_mzml(DAD_filepath, what = "DAD", verbose = FALSE,
                         data_format = "wide")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -73,3 +73,4 @@ test_that("check for pkg returns error for fake package", {
 test_that("get_filetype returns error for unknown filetype", {
   expect_error(get_filetype("testdata/dad1.csv"))
 })
+


### PR DESCRIPTION
* Fixed `write_mzml` to write DAD spectra correctly.
* Added chromatograms to mzML files written by `write_mzml`.
* Fixed bug causing failure to write existing timestamp data to `.cdf` files.
